### PR TITLE
Normal Approximation of Posterior

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mapbayr
 Title: MAP-Bayesian Estimation of PK Parameters
-Version: 0.4.1.9004
+Version: 0.4.1.9005
 Authors@R: 
     person(given = "Felicien",
            family = "Le Louedec",

--- a/R/mapbayest.R
+++ b/R/mapbayest.R
@@ -7,6 +7,7 @@
 #' @param x the model object
 #' @param data NMTRAN-like data set
 #' @param method optimization method; possible values are `L-BFGS-B` (the default) and `newuoa`
+#' @param standard_error a logical. If TRUE, will return standard errors around the estimate and the Fisher Information Matrix (FIM)
 #' @param force_initial_eta a vector of numeric values to start the estimation from (default to 0 for "L-BFGS-B")
 #' @param quantile_bound a numeric value representing the quantile of the normal distribution admitted to define the bounds for L-BFGS-B (default is 0.001, i.e. 0.1%)
 #' @param control a list passed to the optimizer (see \code{\link{optimx}} documentation)
@@ -23,6 +24,7 @@
 mapbayest <- function(x,
                    data = NULL,
                    method = "L-BFGS-B",
+                   standard_error = FALSE,
                    force_initial_eta = NULL,
                    quantile_bound = 0.001,
                    control = list(),
@@ -44,7 +46,7 @@ mapbayest <- function(x,
     check_mapbayr_modeldata(x, data)
   }
 
-  arg.optim   <- preprocess.optim(x, method = method, control = control, force_initial_eta = force_initial_eta, quantile_bound = quantile_bound)
+  arg.optim   <- preprocess.optim(x, method = method, control = control, force_initial_eta = force_initial_eta, quantile_bound = quantile_bound, standard_error = standard_error)
   arg.ofv.fix <- preprocess.ofv.fix(x, data)
 
   iddata <- split_mapbayr_data(data)

--- a/R/mapbayest_check_and_preprocess.R
+++ b/R/mapbayest_check_and_preprocess.R
@@ -123,7 +123,7 @@ split_mapbayr_data <- function(data){
 #' @inheritParams mapbayest
 #' @return a list of named arguments passed to optimizer (i.e. arg.optim)
 #' @export
-preprocess.optim <- function(x, method, control, force_initial_eta, quantile_bound){
+preprocess.optim <- function(x, method, control, force_initial_eta, quantile_bound, standard_error){
   #Checks argument
 
   #method
@@ -170,13 +170,18 @@ preprocess.optim <- function(x, method, control, force_initial_eta, quantile_bou
      bound <- get_quantile(x, .p = quantile_bound)
   }
 
+  #hessian
+  hess <- FALSE
+  if(isTRUE(standard_error)) hess <- standard_error
+
   arg <- list(
     par = initial_eta,
     fn = compute_ofv,
     method = method,
     control = control,
     lower = bound,
-    upper = -bound
+    upper = -bound,
+    hessian = hess
   )
 
   return(arg)

--- a/man/mapbayest.Rd
+++ b/man/mapbayest.Rd
@@ -9,6 +9,7 @@ mapbayest(
   x,
   data = NULL,
   method = "L-BFGS-B",
+  standard_error = FALSE,
   force_initial_eta = NULL,
   quantile_bound = 0.001,
   control = list(),
@@ -26,6 +27,8 @@ mbrest(...)
 \item{data}{NMTRAN-like data set}
 
 \item{method}{optimization method; possible values are \code{L-BFGS-B} (the default) and \code{newuoa}}
+
+\item{standard_error}{a logical. If TRUE, will return standard errors around the estimate and the Fisher Information Matrix (FIM)}
 
 \item{force_initial_eta}{a vector of numeric values to start the estimation from (default to 0 for "L-BFGS-B")}
 

--- a/man/preprocess.optim.Rd
+++ b/man/preprocess.optim.Rd
@@ -4,7 +4,14 @@
 \alias{preprocess.optim}
 \title{Pre-process: arguments for optimization function}
 \usage{
-preprocess.optim(x, method, control, force_initial_eta, quantile_bound)
+preprocess.optim(
+  x,
+  method,
+  control,
+  force_initial_eta,
+  quantile_bound,
+  standard_error
+)
 }
 \arguments{
 \item{x}{the model object}
@@ -16,6 +23,8 @@ preprocess.optim(x, method, control, force_initial_eta, quantile_bound)
 \item{force_initial_eta}{a vector of numeric values to start the estimation from (default to 0 for "L-BFGS-B")}
 
 \item{quantile_bound}{a numeric value representing the quantile of the normal distribution admitted to define the bounds for L-BFGS-B (default is 0.001, i.e. 0.1\%)}
+
+\item{standard_error}{a logical. If TRUE, will return standard errors around the estimate and the Fisher Information Matrix (FIM)}
 }
 \value{
 a list of named arguments passed to optimizer (i.e. arg.optim)

--- a/tests/testthat/test-newini2.R
+++ b/tests/testthat/test-newini2.R
@@ -9,7 +9,7 @@ test_that("new_ini2 works", {
 
   argofv <- c(preprocess.ofv.fix(x = mod), preprocess.ofv.id(x = mod, iddata = data))
 
-  argopt <- preprocess.optim(x = mod, method = "L-BFGS-B", control = list(), force_initial_eta = NULL,
+  argopt <- preprocess.optim(x = mod, method = "L-BFGS-B", control = list(), force_initial_eta = NULL, standard_error = FALSE,
                              quantile_bound = .4) # !!
 
   ini <- new_ini2(arg.ofv = argofv, arg.optim = argopt, run = 1)

--- a/tests/testthat/test-output.R
+++ b/tests/testthat/test-output.R
@@ -98,4 +98,14 @@ test_that("mapbayests object `slots` are correct", {
   expect_length(est3$arg.ofv.id, 2)
   expect_named(est3$arg.ofv.id[[1]], c("data", "DVobs"))
   expect_named(est3$arg.ofv.id[[2]], c("data", "DVobs"))
+
+  expect_null(est3$fisher_information_matrix)
+  expect_null(est3$standard_error)
+
+  #With Hessian and SE
+  est3b <- mapbayest(mod3, data3, verbose = F, standard_error = TRUE)
+  expect_named(est3b, c("model", "data", "arg.optim", "arg.ofv.fix", "arg.ofv.id", "opt.value", "final_eta", "fisher_information_matrix", "standard_error", "mapbay_tab"))
+  expect_true(is.matrix(est3b$fisher_information_matrix[[1]]))
+  expect_length(est3b$fisher_information_matrix, 2)
+  expect_length(est3b$standard_error, 2)
 })


### PR DESCRIPTION
I want mapbayr to return uncertainties about estimations. Here, normal approximation of the posterior.
Add the `standard_error` argument to `mapbayest()` to return FIM and SE. Defaulted to `FALSE`.

To do: 
- Run on performance data. See if no crash when `solve(fim)` if complex models and optimization was difficult. (v9005)

Think about (in the future): 
- Add a CI95% slot. See how to manage the fact that there is two values per ETA. Maybe apply directly on parameters
- Methods to work with this posterior distribution (simulate from this distribution etc... maybe delta method)
- Compare to NONMEM's .phi
