### PR TITLE
derivatives: change to do.call + cbind

### DIFF
--- a/R/mapbayest_ofv_computation.R
+++ b/R/mapbayest_ofv_computation.R
@@ -25,7 +25,7 @@ derivatives <- function(v_DV, v_cmt, cmts){
     LIST[[col_add]]  <- rep.int(1, length(v_DV))
     LIST[[col_add]][!condcmts]  <- 0
   }
-  return(as.matrix(as.data.frame(LIST)))
+  return(do.call(cbind, LIST))
 }
 
 


### PR DESCRIPTION
Something to consider; for a simple computation, it looks to me like most of the time is spent converting the LIST to data frame and then matrix. This can be done directly with `do.call(cbind, LIST)` and much more efficient. 

Just changing that line speeds the computation not quite 10x; some other tweaks could take off some more time, but not a huge amount. I don't know if this will change the overall computation time; I guess it's problem-specific. But it's possible since it gets called every time you compute ofv.

```r
derivatives3 <- function(v_DV, v_cmt, cmts){
  LIST <- list()
  v_DV <- ifelse(v_DV == 0, 1, v_DV)
  for(i in cmts){
    condcmts <- v_cmt == i
    col_prop <- paste0("P", i)
    col_add <- paste0("A", i)
    LIST[[col_prop]] <- v_DV
    LIST[[col_prop]][!condcmts] <- 0
    LIST[[col_add]]  <- rep.int(1, length(v_DV))
    LIST[[col_add]][!condcmts]  <- 0
  }
  return(do.call(cbind, LIST))
}

deriv3 <- function() {
  derivatives3(
    v_DV = c(400, 40, 200, 20),
    v_cmt = c(2, 3, 2, 3),
    cmts = c(2,3)
  ) 
}

> microbenchmark(x <- derv(), y <- deriv3(), z <- deriv2(),  times = 10000)
Unit: microseconds
          expr     min       lq      mean   median       uq
   x <- derv() 264.502 278.8130 315.79851 290.6330 324.0740
 y <- deriv3()  24.241  28.9120  36.47729  33.0065  37.8220
 z <- deriv2()  15.659  18.9725  23.87503  21.5155  26.8055
```