### PR TITLE
Feature/progress

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mapbayr
 Title: MAP-Bayesian Estimation of PK Parameters
-Version: 0.6.0.9001
+Version: 0.6.0.9002
 Authors@R: 
     c(person(given = "Felicien", family = "Le Louedec", 
              role = c("aut", "cre"), 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,6 +20,7 @@ Imports:
     magrittr,
     mrgsolve (>= 1.0.0),
     optimx,
+    progress,
     purrr,
     rlang,
     stringr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,10 @@
 - Change the outputs of pre-processing functions. For fixed elements, `qmod`, `omega_inv `and `all_cmt` now replace `mrgsolve_model`, `omega.inv` and `obs_cmt`. For individual-related elements, `idDV` replaces `DVobs`, `data` is removed, `idvaliddata` and `idcmt` are added. This can have an impact for the user since these elements are reported in the standard output. However, it does not change the behaviour of `get_data()`.
 - new initial values are now computed with `new_ini3`
 - Fix bug: systematic reset if one "ETA" to estimate #116
+- Fix bug: no error at the end of reset-related messages #119
+- Change behaviour of the `verbose` argument: now only controls the messages related to optimization reset, and not the progression of ID being optimized.
+- Implement a progress bar for long-time computation. Can be turned-off with `progress = FALSE`. Displays the number of the ID being optimized. #118 #28
+- add dependency: {progress} package.
 
 # mapbayr 0.6.0
 This version of mapbayr introduces several features that aim to express uncertainty around the point estimate. Please note that the results of these functions were not validated *vs* a gold-standard software such as NONMEM. This is why they are referred as "experimental features" in the following subsections. They are exported with the objective to ease their future validation, and to provide a very rough idea of the estimation uncertainty.

--- a/R/mapbayest.R
+++ b/R/mapbayest.R
@@ -12,7 +12,8 @@
 #' @param quantile_bound a numeric value representing the quantile of the normal distribution admitted to define the bounds for L-BFGS-B (default is 0.001, i.e. 0.1%)
 #' @param control a list passed to the optimizer (see \code{\link{optimx}} documentation)
 #' @param check check model code for mapbayr specification (a logical, default is `TRUE`)
-#' @param verbose print the steps of the estimations to the console (a logical, default is `TRUE`)
+#' @param verbose print a message whenever optimization is reset (a logical, default is `TRUE`)
+#' @param progress print a progress bar (a logical, default is `TRUE`)
 #' @param reset reset optimizer with new initial eta values if numerical difficulties, or with new bounds (L-BFGS-B) if estimate equal to a bound. (a logical, default is `TRUE`)
 #' @param output if `NULL` (the default) a mapbayests object is returned; if `df` a \emph{mapbay_tab} dataframe is returned
 #'
@@ -63,16 +64,17 @@
 #'@seealso \code{\link{use_posterior}}
 #'
 mapbayest <- function(x,
-                   data = NULL,
-                   method = "L-BFGS-B",
-                   hessian = stats::optimHess,
-                   force_initial_eta = NULL,
-                   quantile_bound = 0.001,
-                   control = list(),
-                   check = TRUE,
-                   verbose = TRUE,
-                   reset = TRUE,
-                   output = NULL
+                      data = NULL,
+                      method = "L-BFGS-B",
+                      hessian = stats::optimHess,
+                      force_initial_eta = NULL,
+                      quantile_bound = 0.001,
+                      control = list(),
+                      check = TRUE,
+                      verbose = TRUE,
+                      progress = TRUE,
+                      reset = TRUE,
+                      output = NULL
 ){
 
   # Start checks and pre-processing (i.e. generating arguments passed to the optimizer)
@@ -103,6 +105,10 @@ mapbayest <- function(x,
   # End checks and pre-processing
   t2 <- Sys.time()
 
+  if(progress){
+    pb <- progress::progress_bar$new(format = "[:bar] ID :current/:total (:percent)", total = length(arg.ofv.id))
+  }
+
   # Start optimization
   opt.value <- map(arg.ofv, do_optimization, arg.optim = arg.optim, verbose = verbose, reset = reset)
 
@@ -114,7 +120,7 @@ mapbayest <- function(x,
     data = iddata,
     opt.value = opt.value,
     arg.ofv = arg.ofv
-    ) %>%
+  ) %>%
     pmap(postprocess.optim,
          x = x,
          hessian = hessian,
@@ -128,7 +134,7 @@ mapbayest <- function(x,
                             post = post,
                             output = output,
                             times = c(t1, t2, t3)
-                            )
+  )
 
   return(out)
 }

--- a/R/mapbayest_optimization.R
+++ b/R/mapbayest_optimization.R
@@ -3,9 +3,9 @@
 # This is the function that realize optimization from the argument arg.ofv, arg.optim etc...
 
 do_optimization <- function(arg.ofv, arg.optim, verbose, reset){
+  try(rlang::caller_env(n = 2)$pb$tick(), silent = TRUE)
 
   # First the optimization is done once.
-  if(verbose) cat(paste0("\nID ", unique(arg.ofv$data$ID), "..."))
   opt <- do.call(quietly(optimx), c(arg.optim, arg.ofv))$result
 
   RUN <- 1
@@ -53,7 +53,6 @@ do_optimization <- function(arg.ofv, arg.optim, verbose, reset){
   }
 
   opt$run <- RUN
-  if(verbose) cat(" done.\n")
   return(opt)
 }
 

--- a/R/mapbayest_optimization.R
+++ b/R/mapbayest_optimization.R
@@ -17,13 +17,13 @@ do_optimization <- function(arg.ofv, arg.optim, verbose, reset){
 
     if(need_new_ini){
       arg.optim$par <- new_ini3(arg.ofv, arg.optim, run = RUN)
-      if(verbose) message("\nDifficulty in optimization. Reset with new initial values: ", paste(arg.optim$par, collapse = ' '), call. = F, immediate. = T)
+      if(verbose) message("Reset with new initial values: ", paste(arg.optim$par, collapse = ' '))
     }
 
     if(need_new_bounds){
       arg.optim$lower <- new_bounds(arg.ofv, arg.optim)
       arg.optim$upper <- -arg.optim$lower
-      if(verbose) message("\nDifficulty in optimization. Reset with new bounds (lower displayed): ", paste(signif(arg.optim$lower), collapse = ' '), call. = F, immediate. = T)
+      if(verbose) message("Reset with new bounds (lower displayed): ", paste(signif(arg.optim$lower), collapse = ' '))
     }
 
     opt <- do.call(quietly(optimx), c(arg.optim, arg.ofv))$result

--- a/man/mapbayest.Rd
+++ b/man/mapbayest.Rd
@@ -15,6 +15,7 @@ mapbayest(
   control = list(),
   check = TRUE,
   verbose = TRUE,
+  progress = TRUE,
   reset = TRUE,
   output = NULL
 )
@@ -38,7 +39,9 @@ mbrest(...)
 
 \item{check}{check model code for mapbayr specification (a logical, default is \code{TRUE})}
 
-\item{verbose}{print the steps of the estimations to the console (a logical, default is \code{TRUE})}
+\item{verbose}{print a message whenever optimization is reset (a logical, default is \code{TRUE})}
+
+\item{progress}{print a progress bar (a logical, default is \code{TRUE})}
 
 \item{reset}{reset optimizer with new initial eta values if numerical difficulties, or with new bounds (L-BFGS-B) if estimate equal to a bound. (a logical, default is \code{TRUE})}
 

--- a/tests/testthat/test-progress.R
+++ b/tests/testthat/test-progress.R
@@ -1,6 +1,6 @@
 test_that("progress bar works", {
   testthat::skip("cannot test progress bar")
-
+# works manually, but not through automatic testing procedures
   code1 <- "$PARAM ETA1 = 0, ETA2 = 0, KA = 0.5, TVCL = 1.1, TVV = 23.3
  $OMEGA 0.41 0.32
  $SIGMA 0.04 0

--- a/tests/testthat/test-progress.R
+++ b/tests/testthat/test-progress.R
@@ -1,7 +1,4 @@
-test_that("progress bar works", {
-  testthat::skip("cannot test progress bar")
-# works manually, but not through automatic testing procedures
-  code1 <- "$PARAM ETA1 = 0, ETA2 = 0, KA = 0.5, TVCL = 1.1, TVV = 23.3
+code1 <- "$PARAM ETA1 = 0, ETA2 = 0, KA = 0.5, TVCL = 1.1, TVV = 23.3
  $OMEGA 0.41 0.32
  $SIGMA 0.04 0
  $CMT DEPOT CENT
@@ -12,12 +9,23 @@ test_that("progress bar works", {
  double DV=CENT/V*(1+EPS(1))+EPS(2);
  $PKMODEL ncmt = 1, depot = TRUE
  $CAPTURE DV CL"
+my_model <- mrgsolve::mcode("my_model", code1)
+my_data <- data.frame(ID = 1, time = c(0,12), evid = c(1,0), mdv = c(1,0), amt = c(500,0), cmt = c(1,2), DV = c(0, 10))
 
-  my_model <- mrgsolve::mcode("my_model", code1)
-  my_data <- data.frame(ID = 1, TIME = c(0,12), EVID = c(1,0), AMT = c(500,0), CMT = c(1,2), DV = c(0, 10))
+test_that("progress argument works", {
+  testthat::skip("cannot test progress bar")
+  # works manually, but not through automatic testing procedures
+
   my_data10 <- seq(10) %>%
     map_dfr(.f = ~ mutate(my_data, ID = .x))
 
   expect_message(mapbayest(x = my_model, my_data10), "\\[=====")
   expect_message(mapbayest(x = my_model, my_data10, progress = FALSE), NA)
+})
+
+test_that("do_optimization works outside the call of mapbayest", {
+  arg.ofv <- c(preprocess.ofv.fix(x = my_model, data = my_data), preprocess.ofv.id(x = my_model, iddata = my_data))
+  arg.optim <- preprocess.optim(x = my_model, method = "L-BFGS-B", control = list(), force_initial_eta = NULL, quantile_bound = 0.001)
+
+  expect_error(do_optimization(arg.ofv, arg.optim, verbose = F, reset = T), NA)
 })

--- a/tests/testthat/test-test-progress.R
+++ b/tests/testthat/test-test-progress.R
@@ -1,0 +1,23 @@
+test_that("progress bar works", {
+  testthat::skip("cannot test progress bar")
+
+  code1 <- "$PARAM ETA1 = 0, ETA2 = 0, KA = 0.5, TVCL = 1.1, TVV = 23.3
+ $OMEGA 0.41 0.32
+ $SIGMA 0.04 0
+ $CMT DEPOT CENT
+ $PK
+ double CL=TVCL*exp(ETA1+ETA(1));
+ double V=TVV*exp(ETA2+ETA(2)) ;
+ $ERROR
+ double DV=CENT/V*(1+EPS(1))+EPS(2);
+ $PKMODEL ncmt = 1, depot = TRUE
+ $CAPTURE DV CL"
+
+  my_model <- mrgsolve::mcode("my_model", code1)
+  my_data <- data.frame(ID = 1, TIME = c(0,12), EVID = c(1,0), AMT = c(500,0), CMT = c(1,2), DV = c(0, 10))
+  my_data10 <- seq(10) %>%
+    map_dfr(.f = ~ mutate(my_data, ID = .x))
+
+  expect_message(mapbayest(x = my_model, my_data10), "\\[=====")
+  expect_message(mapbayest(x = my_model, my_data10, progress = FALSE), NA)
+})

--- a/tests/testthat/test-verbose.R
+++ b/tests/testthat/test-verbose.R
@@ -1,10 +1,10 @@
-test_that("verbose works on difficulty warning", {
-  mod <- mread('ex_mbr1', mbrlib())
-  data <- mod %>%
+mod <- mread('ex_mbr1', mbrlib())
+data <- mod %>%
     adm_lines(amt = 10, addl = 2, ii = 12) %>%
     obs_lines(DV = c(5, 10), time = c(18, 40)) %>%
     get_data()
 
-  expect_message(mapbayest(mod, data), "Difficulty in optimization")
+test_that("verbose works on difficulty warning", {
+  expect_message(mapbayest(mod, data), "Reset with ")
   expect_message(mapbayest(mod, data, verbose = FALSE), NA)
 })

--- a/tests/testthat/test-verbose.R
+++ b/tests/testthat/test-verbose.R
@@ -1,15 +1,3 @@
-test_that("mapbayest verbose works", {
-  mod <- mread('ex_mbr1', mbrlib())
-  data <- mod %>%
-    adm_lines(amt = 10, addl = 2, ii = 12) %>%
-    obs_lines(DV = c(.1, .2), time = c(18, 40)) %>%
-    get_data()
-
-  expect_output(mapbayest(mod, data))
-  expect_output(mapbayest(mod, data, verbose = T))
-  expect_output(mapbayest(mod, data, verbose = F), regexp = NA)
-})
-
 test_that("verbose works on difficulty warning", {
   mod <- mread('ex_mbr1', mbrlib())
   data <- mod %>%
@@ -17,6 +5,6 @@ test_that("verbose works on difficulty warning", {
     obs_lines(DV = c(5, 10), time = c(18, 40)) %>%
     get_data()
 
-  invisible(capture.output(expect_message(mapbayest(mod, data), "Difficulty")))
-  expect_warning(mapbayest(mod, data, verbose = FALSE), NA)
+  expect_message(mapbayest(mod, data), "Difficulty in optimization")
+  expect_message(mapbayest(mod, data, verbose = FALSE), NA)
 })


### PR DESCRIPTION
- Fix bug: no error at the end of reset-related messages #119
- Change behaviour of the `verbose` argument: now only controls the messages related to optimization reset, and not the progression of ID being optimized.
- Implement a progress bar for long-time computation. Can be turned-off with `progress = FALSE`. Displays the number of the ID being optimized. #118 #28
- add dependency: {progress} package.