### PR TITLE
log small negative values fix #140

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
-# mapbayr 0.7.3.9002 (Development version)
+# mapbayr 0.7.3.9003 (Development version)
 - New functions `summarise_phi()` and `bar_phi()` to summarise the comparison of estimation of mapbayr and NONMEM (i.e. classify it as Excellent/Acceptable/Discordant), and to graphically represent it as a bar plot. 
 - Fix a bug where "vs_nonmem" functions could not work if covariance was missing/failing in mapbayests object.
+- Fix a bug where small negative predicted concentrations generated NaN after log-transformation. #140
 
 # mapbayr 0.7.3
 - Minor changes in DESCRIPTION file (CRAN requirements)

--- a/R/mapbayest_ofv_computation.R
+++ b/R/mapbayest_ofv_computation.R
@@ -75,7 +75,14 @@ compute_ofv <- function(eta, qmod, sigma, omega_inv, all_cmt, log_transformation
 
   #Predict concentrations
   pred <- f(qmod = qmod, data = idvaliddata)
-  if(log_transformation) pred <- log(pred)
+  if(log_transformation){
+    abspred <- abs(pred)
+    small <- abspred < sqrt(.Machine$double.eps)
+    if(any(small)){
+      pred[small] <- abspred[small]
+    }
+    pred <- log(pred)
+  }
 
   #Compute variance associated to predictions
   H <- h(pred = pred, cmt = idcmt, all_cmt = all_cmt)


### PR DESCRIPTION
Fixes a bug where small negative values generated contaminating NaN after log-transformation. #140 