### PR TITLE
Feature/select eta hist

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 * OMEGA values equal to zero are allowed and will be ignored during the estimations steps thanks to the new `select_eta` argument.
 * Modification of the final estimation object: `arg.optim` now has a `select_eta` element, `arg.ofv.fix$omega_inv` now has the dimensions of the number of ETAs selected.
 * Small changes in the `print` method.
+* New argument `select_eta` in `hist()` in order to select the ETAs to plot. Default are ETAs estimated (#167).
 
 # mapbayr 0.8.0
 

--- a/R/mapbayests.R
+++ b/R/mapbayests.R
@@ -141,7 +141,7 @@ plot.mapbayests <- function(x, ..., PREDICTION = c("IPRED", "PRED")){
 #' Plot posterior distribution of bayesian estimates
 #'
 #' @param x A \code{mapbayests} object.
-#' @param select_eta number of the ETAs to plot (default are the ETAs estimated).
+#' @param select_eta a vector of numeric values, the numbers of the ETAs to show (default are estimated ETAs).
 #' @param ... additional arguments (not used)
 #' @return a `ggplot` object.
 #'
@@ -151,8 +151,17 @@ plot.mapbayests <- function(x, ..., PREDICTION = c("IPRED", "PRED")){
 #'
 #' @examples
 #' est <- mapbayest(exmodel(ID = 1))
-#' hist(est) +
+#'
+#' # Default Method
+#' h <- hist(est)
+#'
+#' # Can be modified with `ggplot2`
+#' h +
 #'   ggplot2::labs(title = "Awesome estimations")
+#'
+#' # Select the ETAs
+#' hist(est, select_eta = c(1,3))
+#'
 #' @method hist mapbayests
 #' @export
 hist.mapbayests <- function(x, select_eta = x$arg.optim$select_eta, ...){
@@ -191,11 +200,11 @@ hist.mapbayests <- function(x, select_eta = x$arg.optim$select_eta, ...){
   arg_tab$lower <- bound
   arg_tab$upper <- -bound
 
-  # Update bound with those currently used in estimation if ever
+  # Updates bound with those currently used in estimation if ever
   arg_tab$lower[select_eta_est] <- x$arg.optim$lower
   arg_tab$upper[select_eta_est] <- x$arg.optim$upper
 
-  #Then filter select eta for the plot
+  # Then filter the selected ETAs for the plot
   arg_tab <- arg_tab[select_eta_hist,]
 
   # --- Eta tab

--- a/R/mapbayests.R
+++ b/R/mapbayests.R
@@ -185,8 +185,6 @@ hist.mapbayests <- function(x, select_eta = x$arg.optim$select_eta, ...){
            ": maximum ", max_eta, " ETAs defined in $PARAM.")
   }
 
-  common_eta <- intersect(select_eta_est, select_eta_hist)
-
   # --- Arguments tab
   # First on all ETAs for simplicity of indexation
   arg_tab <- data.frame(

--- a/R/mapbayests.R
+++ b/R/mapbayests.R
@@ -141,7 +141,7 @@ plot.mapbayests <- function(x, ..., PREDICTION = c("IPRED", "PRED")){
 #' Plot posterior distribution of bayesian estimates
 #'
 #' @param x A \code{mapbayests} object.
-#' @param select_eta number of the ETAs to plot.
+#' @param select_eta number of the ETAs to plot (default are the ETAs estimated).
 #' @param ... additional arguments (not used)
 #' @return a `ggplot` object.
 #'
@@ -155,7 +155,7 @@ plot.mapbayests <- function(x, ..., PREDICTION = c("IPRED", "PRED")){
 #'   ggplot2::labs(title = "Awesome estimations")
 #' @method hist mapbayests
 #' @export
-hist.mapbayests <- function(x, select_eta = NULL, ...){
+hist.mapbayests <- function(x, select_eta = x$arg.optim$select_eta, ...){
 
   max_eta <- eta_length(x$model)
   select_eta_est <- x$arg.optim$select_eta
@@ -166,8 +166,14 @@ hist.mapbayests <- function(x, select_eta = NULL, ...){
   }
 
   select_eta_hist <- select_eta
+
   if(is.null(select_eta_hist)){
     select_eta_hist <- select_eta_est
+  }
+
+  if(any(select_eta_hist > max_eta)){
+      stop("Cannot select ", paste(make_eta_names(select_eta_hist[select_eta_hist>max_eta]), collapse = " "),
+           ": maximum ", max_eta, " ETAs defined in $PARAM.")
   }
 
   common_eta <- intersect(select_eta_est, select_eta_hist)

--- a/man/hist.mapbayests.Rd
+++ b/man/hist.mapbayests.Rd
@@ -4,10 +4,12 @@
 \alias{hist.mapbayests}
 \title{Plot posterior distribution of bayesian estimates}
 \usage{
-\method{hist}{mapbayests}(x, ...)
+\method{hist}{mapbayests}(x, select_eta = NULL, ...)
 }
 \arguments{
 \item{x}{A \code{mapbayests} object.}
+
+\item{select_eta}{number of the ETAs to plot.}
 
 \item{...}{additional arguments (not used)}
 }

--- a/man/hist.mapbayests.Rd
+++ b/man/hist.mapbayests.Rd
@@ -9,7 +9,7 @@
 \arguments{
 \item{x}{A \code{mapbayests} object.}
 
-\item{select_eta}{number of the ETAs to plot (default are the ETAs estimated).}
+\item{select_eta}{a vector of numeric values, the numbers of the ETAs to show (default are estimated ETAs).}
 
 \item{...}{additional arguments (not used)}
 }
@@ -25,6 +25,15 @@ For additional modifications, you can add extra \verb{+function(...)} in order t
 }
 \examples{
 est <- mapbayest(exmodel(ID = 1))
-hist(est) +
+
+# Default Method
+h <- hist(est)
+
+# Can be modified with `ggplot2`
+h +
   ggplot2::labs(title = "Awesome estimations")
+
+# Select the ETAs
+hist(est, select_eta = c(1,3))
+
 }

--- a/man/hist.mapbayests.Rd
+++ b/man/hist.mapbayests.Rd
@@ -4,12 +4,12 @@
 \alias{hist.mapbayests}
 \title{Plot posterior distribution of bayesian estimates}
 \usage{
-\method{hist}{mapbayests}(x, select_eta = NULL, ...)
+\method{hist}{mapbayests}(x, select_eta = x$arg.optim$select_eta, ...)
 }
 \arguments{
 \item{x}{A \code{mapbayests} object.}
 
-\item{select_eta}{number of the ETAs to plot.}
+\item{select_eta}{number of the ETAs to plot (default are the ETAs estimated).}
 
 \item{...}{additional arguments (not used)}
 }

--- a/tests/testthat/test-hist.R
+++ b/tests/testthat/test-hist.R
@@ -1,25 +1,7 @@
-test_that("hist.mapbayests works", {
-  hist1 <- hist(mapbayest(exmodel()))
-  hist001 <- hist(est001)
-
-  expect_s3_class(hist1$layers[[1]]$geom, "GeomArea")
-  expect_s3_class(hist1$layers[[2]]$geom, "GeomLine")
-  expect_s3_class(hist1$layers[[3]]$geom, "GeomSegment")
-  expect_s3_class(hist1$layers[[4]]$geom, "GeomSegment")
-  expect_s3_class(hist1$layers[[5]]$geom, "GeomRug")
-  expect_s3_class(hist1$layers[[6]]$geom, "GeomBar")
-
-  labelhist1 <- eval(quote(pairlist(...)), envir = environment(hist1[["facet"]][["params"]][["labeller"]]))[["name"]][["ETA1"]]
-  labelhist001 <- eval(quote(pairlist(...)), envir = environment(hist001[["facet"]][["params"]][["labeller"]]))[["name"]][["ETA1"]]
-
-  expect_true(str_detect(labelhist1,  "ID percentile"))
-  expect_true(!str_detect(labelhist001, "ID percentile"))
-})
-
-test_that("facetting order is ok if nETA >= 10", {
-  code <- "
-$PARAM ETA1 = 0, ETA2 = 0, ETA3= 0, ETA4 = 0, ETA5 = 0,
-ETA6 = 0, ETA7 = 0, ETA8 = 0, ETA9 = 0, ETA10 = 0, ETA11 = 0, ETA12 = 0
+code_hist <- "
+$PARAM
+ETA1 = 0, ETA2 = 0, ETA3= 0, ETA4 = 0, ETA5 = 0, ETA6 = 0,
+ETA7 = 0, ETA8 = 0, ETA9 = 0, ETA10 = 0, ETA11 = 0, ETA12 = 0
 $OMEGA .1 .2 .3 .4 .1 .1 .1 .1 .1 .11 .11 .11
 $CMT CENT GUT
 $SIGMA 1 0
@@ -27,13 +9,64 @@ $TABLE
 double DV = 100.0 ;
 $CAPTURE DV
 "
-  mod <- mrgsolve::mcode("mod", code)
-  dat <- exdata()
-  est <- mapbayest(mod, dat, reset = 0, verbose = FALSE)
-  H <- hist(est)
-  layout <- ggplot2::ggplot_build(H)$layout
-  test_names <- layout$layout[names(layout$facet$params$facets)]$name
-  expected_names <- make_eta_names(n = 12)
-  expect_equal(levels(test_names), expected_names)
-  expect_equal(as.character(test_names), expected_names)
+
+mod_hist <- mrgsolve::mcode("mod12", code_hist)
+dat_hist <- exdata()
+est_hist <- mapbayest(mod_hist, dat_hist, reset = 0, verbose = FALSE)
+hist_hist <- hist(est_hist)
+
+fetch_facet_names <- function(x){
+  layout <- ggplot2::ggplot_build(x)$layout
+  layout$layout[names(layout$facet$params$facets)]$name
+}
+
+test_that("hist.mapbayests works", {
+  expect_s3_class(hist_hist$layers[[1]]$geom, "GeomArea")
+  expect_s3_class(hist_hist$layers[[2]]$geom, "GeomLine")
+  expect_s3_class(hist_hist$layers[[3]]$geom, "GeomSegment")
+  expect_s3_class(hist_hist$layers[[4]]$geom, "GeomSegment")
+  expect_s3_class(hist_hist$layers[[5]]$geom, "GeomRug")
+  expect_s3_class(hist_hist$layers[[6]]$geom, "GeomBar")
+})
+
+test_that("ID percentile is not shown if n ID > 1", {
+  label_hist <- eval(quote(pairlist(...)), envir = environment(hist_hist[["facet"]][["params"]][["labeller"]]))[["name"]][["ETA1"]]
+  expect_true(str_detect(label_hist,  "ID percentile"))
+
+  hist001 <- hist(est001)
+  labelhist001 <- eval(quote(pairlist(...)), envir = environment(hist001[["facet"]][["params"]][["labeller"]]))[["name"]][["ETA1"]]
+  expect_true(!str_detect(labelhist001, "ID percentile"))
+})
+
+test_that("facetting order is ok if nETA >= 10", {
+  expected_names <- c("ETA1", "ETA2", "ETA3", "ETA4", "ETA5", "ETA6", "ETA7", "ETA8", "ETA9", "ETA10", "ETA11", "ETA12")
+  expected_names <- factor(x = expected_names, levels = expected_names)
+  expect_equal(fetch_facet_names(hist_hist), expected_names)
+})
+
+test_that("select_eta argument works", {
+  expect_equal(
+    fetch_facet_names(hist(est_hist, select_eta = c(1,3,5))),
+    factor(x = make_eta_names(c(1,3,5)), levels = make_eta_names(c(1,3,5)))
+  )
+
+  # Even if estimation on a subset of ETAs
+  est135 <- mapbayest(mod_hist, dat_hist, reset = 0, verbose = FALSE, select_eta = c(1,3,5))
+
+  # Default to estimated ETAs
+  expect_equal(
+    fetch_facet_names(hist(est135)),
+    factor(x = make_eta_names(c(1,3,5)), levels = make_eta_names(c(1,3,5)))
+  )
+
+  expect_equal(
+    fetch_facet_names(hist(est135, select_eta = c(1,3))),
+    factor(x = make_eta_names(c(1,3)), levels = make_eta_names(c(1,3)))
+  )
+
+  # Even if none are common
+  expect_equal(
+    fetch_facet_names(hist(est135, select_eta = c(2,4,6))),
+    factor(x = make_eta_names(c(2,4,6)), levels = make_eta_names(c(2,4,6)))
+  )
 })

--- a/tests/testthat/test-hist.R
+++ b/tests/testthat/test-hist.R
@@ -69,4 +69,10 @@ test_that("select_eta argument works", {
     fetch_facet_names(hist(est135, select_eta = c(2,4,6))),
     factor(x = make_eta_names(c(2,4,6)), levels = make_eta_names(c(2,4,6)))
   )
+
+  # Error if select > max ETA
+  expect_error(
+    fetch_facet_names(hist(est135, select_eta = c(13, 14))),
+    "Cannot select ETA13 ETA14: maximum 12 ETAs defined in \\$PARAM."
+  )
 })


### PR DESCRIPTION
# Summary
* New argument `select_eta` in `hist()` in order to select the ETAs to plot. Default are ETAs estimated (#167).
