### PR TITLE
Miscellaneous

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,10 @@ Authors@R:
              comment = c(ORCID = "0000-0003-3699-2729")),
       person(given = "Kyle T", family = "Baron", 
              role = "ctb", 
-             comment = c(ORCID = "0000-0001-7252-5656")))
+             comment = c(ORCID = "0000-0001-7252-5656")), 
+      person(given = "Laura", family = "Morvan", 
+             role = "ctb")
+             )
 Description: Performs maximum a posteriori Bayesian estimation of individual pharmacokinetic parameters from a model defined in 'mrgsolve', typically for model-based therapeutic drug monitoring. Internally computes an objective function value from model and data, performs optimization and returns predictions in a convenient format. The performance of the package was described by Le Louedec et al (2021) <doi:10.1002/psp4.12689>.
 License: GPL-3
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 * The `mapbay_tab` now has the same number of rows as original data especially if it did not have observation rows (@LauraMvn, #193).
 * With data helpers, the `.datehour` column is updated after `realize_addl` is being called (@LauraMvn, #194).
 * Add Laura Morvan @LauraMvn as contributor.
+* "ETA" parameters cannot be longer declared as "@covariates" to avoid hazardous behaviours (@jbwoillard, #187).
 
 # mapbayr 0.9.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 * By default, `augment()` now simulates at least 200 points per individual. Fix a bug where delta was mis-calculated and strange-looking plots were sometimes generated. (#191)
 * `hist()` now shows the values of eta-shrinkage in multiple subjects setting. New argument `shk` to control the definition of shrinkage, either based on standard deviation ("sd") or on variance ("var"). (#192)
 * The `mapbay_tab` now has the same number of rows as original data especially if it did not have observation rows. (#193) 
+* With data helpers, the `.datehour` column is updated after `realize_addl` is being called. (#194)
 
 
 # mapbayr 0.9.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,11 +3,11 @@
 * New `model_averaging()` to make averaged predictions over estimations made from several models. Also exports `do_model_averaging()` and `compute_weights()` for low-level implementation.
 * Model averaging can now be performed on data frame with non-numeric columns. #197
 * New `mapbayr_plot()` in order to plot results from tables (data.frame). This is the function now called by `plot.mapbayests()` internally. Can plot the results of multiple estimation object (informed in the column "MODEL"), useful when model averaging is performed. Argument `MODEL_color` to force the color of a model on the plot. 
-* By default, `augment()` now simulates at least 200 points per individual. Fix a bug where delta was mis-calculated and strange-looking plots were sometimes generated. (#191)
-* `hist()` now shows the values of eta-shrinkage in multiple subjects setting. New argument `shk` to control the definition of shrinkage, either based on standard deviation ("sd") or on variance ("var"). (#192)
-* The `mapbay_tab` now has the same number of rows as original data especially if it did not have observation rows. (#193) 
-* With data helpers, the `.datehour` column is updated after `realize_addl` is being called. (#194)
-
+* By default, `augment()` now simulates at least 200 points per individual. Fix a bug where delta was mis-calculated and strange-looking plots were sometimes generated (@LauraMvn, #191).
+* `hist()` now shows the values of eta-shrinkage in multiple subjects setting. New argument `shk` to control the definition of shrinkage, either based on standard deviation ("sd") or on variance ("var") (@LauraMvn, #192).
+* The `mapbay_tab` now has the same number of rows as original data especially if it did not have observation rows (@LauraMvn, #193).
+* With data helpers, the `.datehour` column is updated after `realize_addl` is being called (@LauraMvn, #194).
+* Add Laura Morvan @LauraMvn as contributor.
 
 # mapbayr 0.9.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * Model averaging can now be performed on data frame with non-numeric columns. #197
 * New `mapbayr_plot()` in order to plot results from tables (data.frame). This is the function now called by `plot.mapbayests()` internally. Can plot the results of multiple estimation object (informed in the column "MODEL"), useful when model averaging is performed. Argument `MODEL_color` to force the color of a model on the plot. 
 * By default, `augment()` now simulates at least 200 points per individual. Fix a bug where delta was mis-calculated and strange-looking plots were sometimes generated. (#191)
+* `hist()` now shows the values of eta-shrinkage in multiple subjects setting. New argument `shk` to control the definition of shrinkage, either based on standard deviation ("sd") or on variance ("var"). 
 
 # mapbayr 0.9.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 * New `model_averaging()` to make averaged predictions over estimations made from several models. Also exports `do_model_averaging()` and `compute_weights()` for low-level implementation.
 * Model averaging can now be performed on data frame with non-numeric columns. #197
 * New `mapbayr_plot()` in order to plot results from tables (data.frame). This is the function now called by `plot.mapbayests()` internally. Can plot the results of multiple estimation object (informed in the column "MODEL"), useful when model averaging is performed. Argument `MODEL_color` to force the color of a model on the plot. 
-
+* By default, `augment()` now simulates at least 200 points per individual. Fix a bug where delta was mis-calculated and strange-looking plots were sometimes generated. (#191)
 
 # mapbayr 0.9.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,9 @@
 * Model averaging can now be performed on data frame with non-numeric columns. #197
 * New `mapbayr_plot()` in order to plot results from tables (data.frame). This is the function now called by `plot.mapbayests()` internally. Can plot the results of multiple estimation object (informed in the column "MODEL"), useful when model averaging is performed. Argument `MODEL_color` to force the color of a model on the plot. 
 * By default, `augment()` now simulates at least 200 points per individual. Fix a bug where delta was mis-calculated and strange-looking plots were sometimes generated. (#191)
-* `hist()` now shows the values of eta-shrinkage in multiple subjects setting. New argument `shk` to control the definition of shrinkage, either based on standard deviation ("sd") or on variance ("var"). 
+* `hist()` now shows the values of eta-shrinkage in multiple subjects setting. New argument `shk` to control the definition of shrinkage, either based on standard deviation ("sd") or on variance ("var"). (#192)
+* The `mapbay_tab` now has the same number of rows as original data especially if it did not have observation rows. (#193) 
+
 
 # mapbayr 0.9.0
 

--- a/R/data_helpers.R
+++ b/R/data_helpers.R
@@ -550,6 +550,11 @@ rearrange_nmdata <- function(x, dh0 = NULL) {
   if (!any(is.null(x[["ID"]]), is.null(x[["time"]]), is.null(x[["evid"]]), is.null(x[["cmt"]]))) {
     x <- arrange(x, .data$ID, .data$time, desc(.data$evid), .data$cmt)
   }
+
+  # Fill AOLA/TOLA if exists
+  if (!is.null(x[["AOLA"]])) x <- AOLA(x)
+  if (!is.null(x[["TOLA"]])) x <- TOLA(x)
+
   # Fill .datehour if exists or requested
   if (any(!is.null(x[[".datehour"]]), !is.null(dh0))) {
     if (is.null(dh0)) {
@@ -557,10 +562,6 @@ rearrange_nmdata <- function(x, dh0 = NULL) {
     }
     x[[".datehour"]] <- dh0 + x$time * 60 * 60
   }
-
-  # Fill AOLA/TOLA if exists
-  if (!is.null(x[["AOLA"]])) x <- AOLA(x)
-  if (!is.null(x[["TOLA"]])) x <- TOLA(x)
 
   nmtran <- c("ID", "time", "evid", "cmt", "amt", "DV", "mdv", "ss", "addl", "ii", "rate")
   # Relocate

--- a/R/mapbayest_check_and_preprocess.R
+++ b/R/mapbayest_check_and_preprocess.R
@@ -50,6 +50,10 @@ check_mapbayr_model <- function(x, check_compile = TRUE){
       }
     }
 
+    if(length(intersect(mbr_cov_names(x), eta_names_x)) > 0){
+      stop("$PARAM. One or several ETA parameter(s) are declared as `@covariates`, which is not allowed.", call. = FALSE)
+    }
+
     # $OMEGA
     odiag_x <- odiag(x)
     nomega <- length(odiag_x)

--- a/R/mapbayest_postprocess.R
+++ b/R/mapbayest_postprocess.R
@@ -11,12 +11,15 @@ dataeta <- function(data, eta){
 
 post_mapbay_tab <- function(x, data, etamat){
   # PRED
-  pred <- mrgsim_df(zero_re(x), data, Req = "DV")[["DV"]]
+  pred <- mrgsim_df(zero_re(x), data, Req = "DV", end = -1)[["DV"]]
 
   # IPRED and POST HOC parameters
   dataposthoc <- dataeta(data = data, eta = etamat)
   capturednames <- outvars(x)$capture
-  posthocsims <- mrgsim_df(zero_re(x), dataposthoc, Req = capturednames) %>%
+  posthocsims <- mrgsim_df(zero_re(x),
+                           dataposthoc,
+                           Req = capturednames,
+                           end = -1) %>%
     rename(IPRED = "DV") %>%
     select(-all_of(c("ID", "time")))
 

--- a/R/mapbayests.R
+++ b/R/mapbayests.R
@@ -83,6 +83,7 @@ plot.mapbayests <- function(x, ..., PREDICTION = c("IPRED", "PRED")){
 #'
 #' @param x A \code{mapbayests} object.
 #' @param select_eta a vector of numeric values, the numbers of the ETAs to show (default are estimated ETAs).
+#' @param shk method to compute the shrinkage if multiple subjects are analyzed. Possible values are "sd" (based on the ratio of standard deviation like in 'NONMEM'), "var" (based on the ratio of variances like 'Monolix'), or NA (do not show the shrinkage)
 #' @param ... additional arguments (not used)
 #' @return a `ggplot` object.
 #'
@@ -106,7 +107,10 @@ plot.mapbayests <- function(x, ..., PREDICTION = c("IPRED", "PRED")){
 #'}
 #' @method hist mapbayests
 #' @export
-hist.mapbayests <- function(x, select_eta = x$arg.optim$select_eta, ...){
+hist.mapbayests <- function(x,
+                            select_eta = x$arg.optim$select_eta,
+                            shk = c("sd", "var", NA),
+                            ...){
 
   max_eta <- eta_length(x$model)
   select_eta_est <- x$arg.optim$select_eta
@@ -175,6 +179,25 @@ hist.mapbayests <- function(x, select_eta = x$arg.optim$select_eta, ...){
                            mean = 0)
     eta_labs <- paste0(eta_labs,
                        "\nID percentile = ", my_percent(percentile))
+  } else {
+    shk <- shk[1]
+    if(!is.na(shk)){
+      variances <- eta_tab %>%
+        group_by(.data$name) %>%
+        summarise(VAR = stats::var(.data$value)) %>%
+        ungroup()
+      shk_tab <- left_join(arg_tab, variances, by = "name")
+
+      if(shk == "var"){
+        shrinkage <- 1 - (shk_tab$VAR / shk_tab$om)
+      }
+
+      if(shk == "sd"){
+        shrinkage <- 1 - (sqrt(shk_tab$VAR) / sqrt(shk_tab$om))
+      }
+      eta_labs <- paste0(eta_labs,
+                         "\nSHK = ", my_percent(shrinkage))
+    }
   }
 
   names(eta_labs) <- arg_tab$name

--- a/R/mapbayests.R
+++ b/R/mapbayests.R
@@ -258,8 +258,7 @@ augment.mapbayests <- function(x, data = NULL, start = NULL, end = NULL, delta =
   }
 
   if(is.null(delta)){
-    .delta <- (end - start)/200 #approximately 200 points per graph
-    delta <- 10^(round(log10(abs(.delta)))) #rounded to the closer 10 (0.1, 1, 10 etc...)
+    delta <- compute_delta(start = start, end = end)
     #A vector. For each ID, possibly a different delta.
   }
 
@@ -341,6 +340,12 @@ augment.mapbayests <- function(x, data = NULL, start = NULL, end = NULL, delta =
 
   class(x) <- "mapbayests"
   return(x)
+}
+
+compute_delta <- function(start = 0, end = 24){
+  # at least 200 points per graph
+  # round delta to the lower 10 (0.1, 1, 10 etc...)
+  10^(floor(log10(abs((end - start)/200))))
 }
 
 data_nid <- function(data, n){

--- a/man/hist.mapbayests.Rd
+++ b/man/hist.mapbayests.Rd
@@ -4,12 +4,14 @@
 \alias{hist.mapbayests}
 \title{Plot posterior distribution of bayesian estimates}
 \usage{
-\method{hist}{mapbayests}(x, select_eta = x$arg.optim$select_eta, ...)
+\method{hist}{mapbayests}(x, select_eta = x$arg.optim$select_eta, shk = c("sd", "var", NA), ...)
 }
 \arguments{
 \item{x}{A \code{mapbayests} object.}
 
 \item{select_eta}{a vector of numeric values, the numbers of the ETAs to show (default are estimated ETAs).}
+
+\item{shk}{method to compute the shrinkage if multiple subjects are analyzed. Possible values are "sd" (based on the ratio of standard deviation like in 'NONMEM'), "var" (based on the ratio of variances like 'Monolix'), or NA (do not show the shrinkage)}
 
 \item{...}{additional arguments (not used)}
 }

--- a/tests/testthat/test-augment.R
+++ b/tests/testthat/test-augment.R
@@ -39,7 +39,7 @@ test_that("end argument works", {
 
   a3 <- augment(est, end = 400)
   expect_equal(max(a3$aug_tab$time[a3$aug_tab$ID==1]), 400)
-  expect_equal(max(a3$aug_tab$time[a3$aug_tab$ID==1]), 400)
+  expect_equal(max(a3$aug_tab$time[a3$aug_tab$ID==3]), 400)
 
   expect_error(augment(est, start = c(0, 100), end = c(100, 200)), NA)
 
@@ -54,6 +54,10 @@ test_that("delta argument works", {
 
   a3 <- augment(est, end = 40000) # if end is high, no sim with small delta
   expect_lt(nrow(a3$aug_tab), 4000) #auto delta = 100
+
+  # fix 191
+  expect_equal(compute_delta(0, 700), 1)
+  #plot(est, end = 700)
 })
 
 test_that("first prediction is not null if SS=1", {

--- a/tests/testthat/test-check_mapbayr_model.R
+++ b/tests/testthat/test-check_mapbayr_model.R
@@ -35,6 +35,13 @@ test_that("$PARAM is well-specified", {
     check_mapbayr_model(mcode2("$PARAM ETA1 = 0, ETA2 = 0.1"), check_compile = FALSE),
     "\\$PARAM. The value of one or multiple ETA parameter\\(s\\) is not 0."
   )
+
+  expect_error(
+    check_mapbayr_model(mcode2("$PARAM @covariates
+                               ETA1 = 0"), check_compile = FALSE),
+    "\\$PARAM. One or several ETA parameter\\(s\\) are declared as `@covariates`, which is not allowed."
+  )
+
 })
 
 test_that("$OMEGA is well-specified", {

--- a/tests/testthat/test-data_helpers.R
+++ b/tests/testthat/test-data_helpers.R
@@ -248,6 +248,18 @@ test_that(".datehour works", {
   )
 })
 
+test_that(".datehour works jointly with AOLA/TOLA", {
+  mod_datehour <- mrgsolve::mcode("modTOLA",
+                                  "$PARAM @annotated @covariates
+                                  TOLA : 0 : time last adm", compile = FALSE)
+
+  data_datehour <-mod_datehour %>%
+    adm_rows(amt = 100, cmt = 1, addl = 3, ii = 24, .datehour = "12/12/2012 12:12") %>%
+    add_covariates() %>%
+    get_data()
+
+  expect_equal(data_datehour[[".datehour"]], parse_datehour(paste0("2012/12/", 12:15, " 12:12:00")))
+})
 
 test_that("AOLA/TOLA works", {
   dat <- tibble::tibble(ID = c(1L, 1L, 1L, 1L, 1L, 3L, 3L, 3L, 3L),

--- a/tests/testthat/test-post_mapbay_tab.R
+++ b/tests/testthat/test-post_mapbay_tab.R
@@ -1,11 +1,18 @@
 library(mapbayr)
-mod <- exmodel(301, add_exdata = F, compile = FALSE)
+mod301 <- exmodel(301, add_exdata = F, cache = TRUE)
 dat <- exdata(301, ID = 1)
+etamat <- matrix(c(0.1, -0.2, 0.3), nrow = 1, dimnames = list("1", c("ETA1", "ETA2", "ETA3")))
 test_that("post_mapbay_tab works if missing covariates", {
   dat$SEX <- NULL
   dat$BW <- NULL
-  etamat <- matrix(c(0.1, -0.2, 0.3), nrow = 1, dimnames = list("1", c("ETA1", "ETA2", "ETA3")))
-  tab <- post_mapbay_tab(x = mod, data = dat, etamat = etamat)
+  tab <- post_mapbay_tab(x = mod301, data = dat, etamat = etamat)
   expect_equal(unique(tab$SEX), 0)
   expect_equal(unique(tab$BW), 75)
+})
+
+test_that("correct number of rows if no observation rows", {
+  expect_equal(
+    nrow(post_mapbay_tab(mod301, dat[1,], etamat = etamat)),
+    1
+  )
 })


### PR DESCRIPTION
* By default, `augment()` now simulates at least 200 points per individual. Fix a bug where delta was mis-calculated and strange-looking plots were sometimes generated (@LauraMvn, #191).
* `hist()` now shows the values of eta-shrinkage in multiple subjects setting. New argument `shk` to control the definition of shrinkage, either based on standard deviation ("sd") or on variance ("var") (@LauraMvn, #192).
* The `mapbay_tab` now has the same number of rows as original data especially if it did not have observation rows (@LauraMvn, #193).
* With data helpers, the `.datehour` column is updated after `realize_addl` is being called (@LauraMvn, #194).
* Add Laura Morvan @LauraMvn as contributor.
* "ETA" parameters cannot be longer declared as "@covariates" to avoid hazardous behaviours (@jbwoillard, #187).